### PR TITLE
feat: show ordered goods selection

### DIFF
--- a/feature/survey/src/main/java/com/cyanlch/survey/model/Models.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/model/Models.kt
@@ -6,6 +6,12 @@ import com.cyanlch.domain.model.anime.AnimeId
 import com.cyanlch.domain.model.anime.CharacterId
 import com.cyanlch.domain.model.goods.GoodsType
 
+data class SelectedGoods(
+    val id: Int,
+    val name: String,
+    val imageUrl: String,
+)
+
 data class SurveyForm(
     val animeCatalog: List<Anime> = emptyList(),
     val selectedAnimeIds: Set<AnimeId> = emptySet(),
@@ -13,7 +19,7 @@ data class SurveyForm(
     val characterListsByAnime: Map<AnimeId, AnimeCharacterList> = emptyMap(),
     val goodsTypes: List<GoodsType> = emptyList(),
     val selectedGoodsTypeIds: Set<Int> = emptySet(),
-    val selectedGoodsIds: Set<Int> = emptySet(),
+    val selectedGoods: List<SelectedGoods> = emptyList(),
 )
 
 enum class SurveyStep { Anime, Character, GoodsType }

--- a/feature/survey/src/main/java/com/cyanlch/survey/model/SurveyStore.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/model/SurveyStore.kt
@@ -119,11 +119,16 @@ class SurveyStore @Inject constructor(
         f.copy(selectedGoodsTypeIds = next)
     }
 
-    fun selectOrDeselectGoods(goodsId: Int) = updateForm { f ->
-        val next = f.selectedGoodsIds.toMutableSet()
-        if (!next.add(goodsId)) next.remove(goodsId)
-        if (next.size > SurveySelectionPolicy.MAX_GOODS) return@updateForm f
-        f.copy(selectedGoodsIds = next)
+    fun selectOrDeselectGoods(goods: SelectedGoods) = updateForm { f ->
+        val next = f.selectedGoods.toMutableList()
+        val existingIndex = next.indexOfFirst { it.id == goods.id }
+        if (existingIndex >= 0) {
+            next.removeAt(existingIndex)
+        } else {
+            if (next.size >= SurveySelectionPolicy.MAX_GOODS) return@updateForm f
+            next.add(goods)
+        }
+        f.copy(selectedGoods = next)
     }
 
     fun selectOrDeselectAllGoodsType() = updateForm { f ->

--- a/feature/survey/src/main/java/com/cyanlch/survey/model/SurveyValidator.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/model/SurveyValidator.kt
@@ -62,7 +62,7 @@ object SurveyValidator {
     }
 
     fun validateGoods(form: SurveyForm): ValidationResult {
-        val chosen = form.selectedGoodsIds
+        val chosen = form.selectedGoods
         val errors = buildList {
             if (chosen.isEmpty()) {
                 add(

--- a/feature/survey/src/main/java/com/cyanlch/survey/search/GoodsSearchScreen.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/search/GoodsSearchScreen.kt
@@ -13,7 +13,7 @@ data object GoodsSearchScreen : Screen {
         val canLoadMore: Boolean,
         val errorMessage: String?,
         val onQueryChange: (String) -> Unit,
-        val onToggleGoods: (Int) -> Unit,
+        val onToggleGoods: (GoodsSearchItem) -> Unit,
         val onLoadMore: () -> Unit,
         val onBack: () -> Unit,
         val onErrorShown: () -> Unit,
@@ -25,4 +25,5 @@ data class GoodsSearchItem(
     val name: String,
     val imageUrl: String,
     val isSelected: Boolean,
+    val order: Int? = null,
 )

--- a/feature/survey/src/main/java/com/cyanlch/survey/search/GoodsSearchUi.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/search/GoodsSearchUi.kt
@@ -96,8 +96,9 @@ private fun GoodsGrid(state: GoodsSearchScreen.State) {
                     imageUrl = item.imageUrl,
                     contentDescription = item.name,
                     selected = item.isSelected,
-                    onClick = { state.onToggleGoods(item.id) },
+                    onClick = { state.onToggleGoods(item) },
                     modifier = Modifier.size(168.dp),
+                    cnt = item.order,
                 )
                 HeightSpacer(4)
                 HgText(

--- a/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionPresenter.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionPresenter.kt
@@ -29,7 +29,7 @@ class GoodsSelectionPresenter @AssistedInject constructor(
         }
 
         return GoodsSelectionScreen.State(
-            selectedGoodsIds = storeState.form.selectedGoodsIds,
+            selectedGoods = storeState.form.selectedGoods,
             onToggleGoods = store::selectOrDeselectGoods,
             onSearchClick = ::onSearchClick,
             onNext = {},

--- a/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionScreen.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionScreen.kt
@@ -1,5 +1,6 @@
 package com.cyanlch.survey.selection
 
+import com.cyanlch.survey.model.SelectedGoods
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.parcelize.Parcelize
@@ -7,8 +8,8 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data object GoodsSelectionScreen : Screen {
     data class State(
-        val selectedGoodsIds: Set<Int>,
-        val onToggleGoods: (Int) -> Unit,
+        val selectedGoods: List<SelectedGoods>,
+        val onToggleGoods: (SelectedGoods) -> Unit,
         val onSearchClick: () -> Unit,
         val onNext: () -> Unit,
         val onSkip: () -> Unit,

--- a/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionUi.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionUi.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,6 +19,7 @@ import com.cyanlch.designsystem.WidthSpacer
 import com.cyanlch.designsystem.button.HgButtonDefaults
 import com.cyanlch.designsystem.button.HgSolidButton
 import com.cyanlch.designsystem.search.HgSearchField
+import com.cyanlch.designsystem.select.HgImageSelector
 import com.cyanlch.designsystem.text.HgText
 import com.cyanlch.designsystem.text.HgTextTone
 import com.cyanlch.designsystem.ui.HGTheme
@@ -52,7 +56,7 @@ class GoodsSelectionUi : Ui<GoodsSelectionScreen.State> {
                         WidthSpacer(4)
                         HgSolidButton(
                             onClick = state.onNext,
-                            enabled = state.selectedGoodsIds.isNotEmpty(),
+                            enabled = state.selectedGoods.isNotEmpty(),
                             modifier = Modifier
                                 .weight(1f),
                         ) {
@@ -110,9 +114,26 @@ private fun GoodsSelectionContent(
                     .fillMaxWidth()
                     .clickable { state.onSearchClick() },
             )
+            SelectedGoodsRow(state)
+        }
+    }
+}
 
-/*            GoodsSelectionField()
-            GoodsListSection()*/
+@Composable
+private fun SelectedGoodsRow(state: GoodsSelectionScreen.State) {
+    if (state.selectedGoods.isEmpty()) return
+    HeightSpacer(16)
+    LazyRow {
+        items(state.selectedGoods) { goods ->
+            HgImageSelector(
+                imageUrl = goods.imageUrl,
+                contentDescription = goods.name,
+                selected = true,
+                onClick = { state.onToggleGoods(goods) },
+                modifier = Modifier.size(84.dp),
+                cnt = state.selectedGoods.indexOf(goods) + 1,
+            )
+            WidthSpacer(8)
         }
     }
 }


### PR DESCRIPTION
## Summary
- track selected goods with metadata and order
- show numbered selections in GoodsSearchUi
- display chosen goods below search bar in GoodsSelectionUi

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb80aebcfc8333a9280d0422bc3abb