### PR TITLE
feat: add grouped goods selection UI

### DIFF
--- a/core/domain/src/main/java/com/cyanlch/domain/model/goods/GoodsSelectionItem.kt
+++ b/core/domain/src/main/java/com/cyanlch/domain/model/goods/GoodsSelectionItem.kt
@@ -1,0 +1,15 @@
+package com.cyanlch.domain.model.goods
+
+import com.cyanlch.domain.model.anime.AnimeId
+
+/**
+ * Represents a goods item along with its parent animation information.
+ */
+data class GoodsSelectionItem(
+    val id: Int,
+    val name: String,
+    val imageUrl: String,
+    val animationId: AnimeId,
+    val animationName: String,
+)
+

--- a/core/domain/src/main/java/com/cyanlch/domain/usecase/survey/FetchGoodsSelectionUseCase.kt
+++ b/core/domain/src/main/java/com/cyanlch/domain/usecase/survey/FetchGoodsSelectionUseCase.kt
@@ -1,0 +1,71 @@
+package com.cyanlch.domain.usecase.survey
+
+import com.cyanlch.domain.model.goods.GoodsSelectionItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class FetchGoodsSelectionUseCase @Inject constructor() {
+    suspend operator fun invoke(): Result<List<GoodsSelectionItem>> {
+        return withContext(Dispatchers.IO) {
+            runCatching { GoodsSelectionFixtures.all }
+        }
+    }
+}
+
+object GoodsSelectionFixtures {
+    private const val SAMPLE_JJK_IMG1 =
+        "https://animate.godohosting.com/Goods/4550621155161.jpg"
+    private const val SAMPLE_JJK_IMG2 =
+        "https://animate.godohosting.com/Goods/4580722007922.jpg"
+    private const val SAMPLE_DS_IMG1 = "https://example.com/goods3.jpg"
+    private const val SAMPLE_DS_IMG2 = "https://example.com/goods4.jpg"
+    private const val SAMPLE_OP_IMG1 = "https://example.com/goods5.jpg"
+    private const val SAMPLE_OP_IMG2 = "https://example.com/goods6.jpg"
+
+    val all: List<GoodsSelectionItem> = listOf(
+        GoodsSelectionItem(
+            id = 1,
+            name = "주술회전 극장판0 스티커/고죠 사토루 유카타",
+            imageUrl = SAMPLE_JJK_IMG1,
+            animationId = 6,
+            animationName = "주술회전",
+        ),
+        GoodsSelectionItem(
+            id = 2,
+            name = "주술회전 자개풍 시리즈 아크릴키홀더 Vol.2 이타도리 유지",
+            imageUrl = SAMPLE_JJK_IMG2,
+            animationId = 6,
+            animationName = "주술회전",
+        ),
+        GoodsSelectionItem(
+            id = 3,
+            name = "귀멸의 칼날 렌고쿠 쿄쥬로 아크릴 스탠드",
+            imageUrl = SAMPLE_DS_IMG1,
+            animationId = 4,
+            animationName = "데몬슬레이어",
+        ),
+        GoodsSelectionItem(
+            id = 4,
+            name = "귀멸의 칼날 탄지로 피규어",
+            imageUrl = SAMPLE_DS_IMG2,
+            animationId = 4,
+            animationName = "데몬슬레이어",
+        ),
+        GoodsSelectionItem(
+            id = 5,
+            name = "원피스 루피 해적왕 모자",
+            imageUrl = SAMPLE_OP_IMG1,
+            animationId = 1,
+            animationName = "원피스",
+        ),
+        GoodsSelectionItem(
+            id = 6,
+            name = "원피스 조로 검 세트",
+            imageUrl = SAMPLE_OP_IMG2,
+            animationId = 1,
+            animationName = "원피스",
+        ),
+    )
+}
+

--- a/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionPresenter.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionPresenter.kt
@@ -1,8 +1,13 @@
 package com.cyanlch.survey.selection
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cyanlch.domain.usecase.survey.FetchGoodsSelectionUseCase
 import com.cyanlch.survey.model.SurveyStore
 import com.cyanlch.survey.search.GoodsSearchScreen
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -14,12 +19,29 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.components.ActivityRetainedComponent
 
 class GoodsSelectionPresenter @AssistedInject constructor(
+    private val fetchGoods: FetchGoodsSelectionUseCase,
     private val store: SurveyStore,
     @Assisted private val navigator: Navigator,
 ) : Presenter<GoodsSelectionScreen.State> {
     @Composable
     override fun present(): GoodsSelectionScreen.State {
         val storeState by store.uiState.collectAsStateWithLifecycle()
+        var items by remember { mutableStateOf(emptyList<GoodsSelectionScreen.GoodsItem>()) }
+
+        LaunchedEffect(Unit) {
+            fetchGoods().onSuccess { list ->
+                items = list.map {
+                    GoodsSelectionScreen.GoodsItem(
+                        id = it.id,
+                        name = it.name,
+                        imageUrl = it.imageUrl,
+                        animationId = it.animationId,
+                        animationName = it.animationName,
+                    )
+                }
+            }
+        }
+
         fun onBack() {
             navigator.pop()
         }
@@ -29,6 +51,7 @@ class GoodsSelectionPresenter @AssistedInject constructor(
         }
 
         return GoodsSelectionScreen.State(
+            items = items,
             selectedGoods = storeState.form.selectedGoods,
             onToggleGoods = store::selectOrDeselectGoods,
             onSearchClick = ::onSearchClick,

--- a/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionScreen.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionScreen.kt
@@ -7,7 +7,16 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data object GoodsSelectionScreen : Screen {
+    data class GoodsItem(
+        val id: Int,
+        val name: String,
+        val imageUrl: String,
+        val animationId: Int,
+        val animationName: String,
+    )
+
     data class State(
+        val items: List<GoodsItem>,
         val selectedGoods: List<SelectedGoods>,
         val onToggleGoods: (SelectedGoods) -> Unit,
         val onSearchClick: () -> Unit,

--- a/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionUi.kt
+++ b/feature/survey/src/main/java/com/cyanlch/survey/selection/GoodsSelectionUi.kt
@@ -2,26 +2,37 @@ package com.cyanlch.survey.selection
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.cyanlch.designsystem.HeightSpacer
 import com.cyanlch.designsystem.WidthSpacer
 import com.cyanlch.designsystem.button.HgButtonDefaults
 import com.cyanlch.designsystem.button.HgSolidButton
 import com.cyanlch.designsystem.search.HgSearchField
+import com.cyanlch.designsystem.select.HgImageSelector
 import com.cyanlch.designsystem.text.HgText
 import com.cyanlch.designsystem.text.HgTextTone
 import com.cyanlch.designsystem.ui.HGTheme
 import com.cyanlch.designsystem.ui.HGTypography
 import com.cyanlch.designsystem.ui.LocalHGColors
 import com.cyanlch.survey.component.SurveyBottomBar
+import com.cyanlch.survey.model.SelectedGoods
 import com.cyanlch.survey.selection.component.SelectedGoodsRow
 import com.cyanlch.ui.topbar.HgBasicTopBar
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -76,42 +87,119 @@ class GoodsSelectionUi : Ui<GoodsSelectionScreen.State> {
 }
 
 @Composable
+private fun GoodsGroup(
+    animationName: String,
+    goods: List<GoodsSelectionScreen.GoodsItem>,
+    selectedGoods: List<SelectedGoods>,
+    onToggleGoods: (SelectedGoods) -> Unit,
+) {
+    var visibleCount by remember(animationName) { mutableStateOf(minOf(4, goods.size)) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        HgText(
+            text = animationName,
+            style = HGTypography.body1SemiBold,
+        )
+        HeightSpacer(8)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            goods.take(visibleCount).forEach { item ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    val isSelected = selectedGoods.any { it.id == item.id }
+                    HgImageSelector(
+                        imageUrl = item.imageUrl,
+                        contentDescription = item.name,
+                        selected = isSelected,
+                        onClick = {
+                            onToggleGoods(SelectedGoods(item.id, item.name, item.imageUrl))
+                        },
+                        modifier = Modifier.size(108.dp),
+                    )
+                    HeightSpacer(4)
+                    HgText(
+                        text = item.name,
+                        style = HGTypography.label1Medium,
+                        maxLines = 2,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+        if (visibleCount < goods.size) {
+            HeightSpacer(8)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        visibleCount = minOf(visibleCount + 6, goods.size)
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                HgText(
+                    text = "더보기",
+                    style = HGTypography.body2SemiBold,
+                    tone = HgTextTone.BrandPrimary,
+                )
+            }
+        }
+        HeightSpacer(24)
+    }
+}
+
+@Composable
 private fun GoodsSelectionContent(
     state: GoodsSelectionScreen.State,
     modifier: Modifier,
-) {
+){
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(LocalHGColors.current.bgDefault)
             .padding(horizontal = 16.dp),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth(),
+        val goodsGroups = state.items.groupBy { it.animationId }
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            HgText(
-                text = "최근 관심 있는 굿즈가 있다면 골라주세요!\n" +
-                    "최저가일 때 알려 드릴게요",
-                style = HGTypography.headlineSemiBold,
-            )
-            HeightSpacer(8)
-            HgText(
-                text = "최대 3개 까지만 선택 가능해요",
-                style = HGTypography.label1Medium,
-                tone = HgTextTone.Assistive,
-            )
-            HeightSpacer(16)
-            HgSearchField(
-                value = "",
-                onValueChange = {},
-                placeholder = "굿즈 이름을 입력해 주세요",
-                enabled = false,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { state.onSearchClick() },
-            )
-            SelectedGoodsRow(state)
+            item {
+                HgText(
+                    text = "최근 관심 있는 굿즈가 있다면 골라주세요!\n" +
+                        "최저가일 때 알려 드릴게요",
+                    style = HGTypography.headlineSemiBold,
+                )
+                HeightSpacer(8)
+                HgText(
+                    text = "최대 3개 까지만 선택 가능해요",
+                    style = HGTypography.label1Medium,
+                    tone = HgTextTone.Assistive,
+                )
+                HeightSpacer(16)
+                HgSearchField(
+                    value = "",
+                    onValueChange = {},
+                    placeholder = "굿즈 이름을 입력해 주세요",
+                    enabled = false,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { state.onSearchClick() },
+                )
+                SelectedGoodsRow(state)
+                HeightSpacer(24)
+            }
+
+            items(goodsGroups.entries.toList()) { entry ->
+                val animationName = entry.value.first().animationName
+                GoodsGroup(
+                    animationName = animationName,
+                    goods = entry.value,
+                    selectedGoods = state.selectedGoods,
+                    onToggleGoods = state.onToggleGoods,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add GoodsSelectionItem model and FetchGoodsSelectionUseCase
- load goods selection data via use case instead of presenter constants
- show fake goods grouped by animation with load-more support
- populate presenter with dummy goods data
- align selection dummy goods with search samples

## Testing
- `./gradlew :feature:survey:test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68bbe9aa72fc8333902182bca53f494e